### PR TITLE
Provide an interface to switch to a project directory

### DIFF
--- a/helm-octopus.el
+++ b/helm-octopus.el
@@ -201,5 +201,18 @@ X must be a `octopus-project-dir-struct' object."
     (propertize (string-join tags " ")
                 'face 'helm-octopus-tag-face)))
 
+(defun helm-octopus-format-dir-org-property (property x)
+  "Extract an Org property.
+
+PROPERTY is a string.
+
+X must be a `octopus-project-dir-struct' object.
+
+You can use `-partial' to build a function that extracts a
+particular property, e.g.
+
+  (-partial #'helm-octopus-format-dir-org-property \"category\")"
+  (cdr (assoc property (octopus-project-dir-struct-properties x))))
+
 (provide 'helm-octopus)
 ;;; helm-octopus.el ends here

--- a/helm-octopus.el
+++ b/helm-octopus.el
@@ -150,6 +150,37 @@ NAME will be the name of the Helm sync source."
 
 ;;;; Project directories
 
+(defun helm-octopus-browse-dir (x)
+  "Helm action for browsing a project directory.
+
+X must be an instance of `octopus-project-dir-struct'."
+  (octopus--browse-dir (octopus-project-dir-struct-dir x)))
+
+(defun helm-octopus-display-marker (x)
+  "Helm action for displaying an Org marker.
+
+X must be an instance of `octopus-project-dir-struct'."
+  (let ((markers (octopus-project-dir-struct-markers x)))
+    (octopus--display-org-marker
+     (octopus--single-or markers
+       (octopus--select-org-marker
+        "Select a subtree to display: " markers
+        :name "Org subtrees for the project")))))
+
+(defcustom helm-octopus-directory-persistent-action
+  #'helm-octopus-display-marker
+  "Persistent action of `helm-octopus-switch-project'."
+  :type 'function)
+
+(defcustom helm-octopus-directory-actions
+  (list (cons "Browse"
+              (-compose #'octopus--browse-dir
+                        #'octopus-project-dir-struct-dir))
+        (cons "Navigate to the Org marker"
+              #'helm-octopus-display-marker))
+  "List of actions to be available in `helm-octopus-switch-project'."
+  :type 'alist)
+
 ;;;###autoload
 (defun helm-octopus-switch-project (candidates)
   "Switch to a project directory.
@@ -162,10 +193,8 @@ CANDIDATES must be a list of `octopus-project-dir-struct' instances."
                    (--map (cons (funcall helm-octopus-project-dir-format-fn it)
                                 it)
                           candidates)
-                   :action
-                   (list (cons "Browse"
-                               (-compose #'octopus--browse-dir
-                                         #'octopus-project-dir-struct-dir))))))
+                   :persistent-action helm-octopus-directory-persistent-action
+                   :action helm-octopus-directory-actions)))
 
 (defun helm-octopus-format-project-dir-struct-1 (x)
   "Format a directory for Helm.

--- a/helm-octopus.el
+++ b/helm-octopus.el
@@ -33,6 +33,7 @@
 
 (require 'octopus-org)
 (require 'octopus-utils)
+(require 'octopus)
 (require 'org)
 (require 'helm)
 (require 'dash)
@@ -167,7 +168,9 @@ CANDIDATES must be a list of `octopus-project-dir-struct' instances."
                                          #'octopus-project-dir-struct-dir))))))
 
 (defun helm-octopus-format-project-dir-struct-1 (x)
-  "Format `octopus-project-dir-struct' instance for Helm."
+  "Format a directory for Helm.
+
+X must be an instance of `octopus-project-dir-struct'."
   (let ((remote (octopus-project-dir-struct-remote x))
         (dir (octopus-project-dir-struct-dir x))
         (time (octopus-project-dir-struct-last-ts-unix x))

--- a/helm-octopus.el
+++ b/helm-octopus.el
@@ -42,6 +42,13 @@
   :group 'octopus
   :group 'helm)
 
+(defcustom helm-octopus-project-dir-format-fn
+  #'helm-octopus-format-project-dir-struct-1
+  "Function used to format `octopus-project-dir-struct' objects in Helm.
+
+It should return a string."
+  :type 'function)
+
 (defun helm-octopus-show-marker (marker)
   "Show an Org MARKER and narrow to it."
   (switch-to-buffer (marker-buffer marker))
@@ -100,17 +107,16 @@ CANDIDATES must be a list of `octopus-project-dir-struct' instances."
         :sources (helm-build-sync-source "Projects"
                    :multiline t
                    :candidates
-                   ;; TODO: Allow customizing the format
                    ;; TODO: Allow including specific properties in the format
-                   (--map (cons (helm-octopus--format-project-dir-struct it)
-                                (octopus-project-dir-struct-dir it))
+                   (--map (cons (funcall helm-octopus-project-dir-format-fn it)
+                                it)
                           candidates)
                    :action
                    (list (cons "Browse"
                                (-compose #'octopus--browse-dir
                                          #'octopus-project-dir-struct-dir))))))
 
-(defun helm-octopus--format-project-dir-struct (x)
+(defun helm-octopus-format-project-dir-struct-1 (x)
   "Format `octopus-project-dir-struct' instance for Helm."
   (let ((remote (octopus-project-dir-struct-remote x))
         (dir (octopus-project-dir-struct-dir x))

--- a/helm-octopus.el
+++ b/helm-octopus.el
@@ -51,6 +51,11 @@
 It should return a string."
   :type 'function)
 
+(defcustom helm-octopus-excluded-org-tags
+  '("ORDERED" "noexport")
+  "List of tags that are not displayed in Helm."
+  :type '(repeat string))
+
 ;;;; Faces
 (defface helm-octopus-remote-face
   '((t (:inherit font-lock-constant-face)))
@@ -168,7 +173,9 @@ CANDIDATES must be a list of `octopus-project-dir-struct' instances."
                  (propertize (octopus--format-time time)
                              'face 'helm-octopus-time-face))
                "\n  "
-               (propertize (string-join (octopus-project-dir-struct-org-tags x) " ")
+               (propertize (string-join (--filter (not (member it helm-octopus-excluded-org-tags))
+                                                  (octopus-project-dir-struct-org-tags x))
+                                        " ")
                            'face 'helm-octopus-tag-face))
          (-non-nil)
          (string-join))))

--- a/octopus-org-ql.el
+++ b/octopus-org-ql.el
@@ -81,7 +81,7 @@ completion interface."
                                  (funcall octopus-headline-format))
                                (propertize 'org-marker marker)))
                          markers))
-          (get-char-property 0 'org-marker choice)))))
+          (get-char-property 0 'org-marker)))))
 
 ;;;; Building queries
 

--- a/octopus-org.el
+++ b/octopus-org.el
@@ -31,6 +31,8 @@
 ;;; Code:
 
 (require 'org)
+(require 'org-element)
+(require 'ts)
 
 (require 'octopus-utils)
 

--- a/octopus-org.el
+++ b/octopus-org.el
@@ -125,5 +125,29 @@ This just calls `octopus-org-files'."
       (goto-char initial)
       (message "Not inside a project subtree"))))
 
+(defun octopus--subtree-timestamp-info ()
+  "Return statistic information on timestamps in the subtree."
+  (org-with-wide-buffer
+   (let ((end (save-excursion
+                (org-end-of-subtree)))
+         (re (org-re-timestamp 'inactive))
+         last-ts
+         (ts-count 0))
+     (while (re-search-forward re end t)
+       (let* ((elm (org-timestamp-from-string (match-string 0)))
+              (ts (make-ts
+                   :year (org-element-property :year-start elm)
+                   :month (org-element-property :month-start elm)
+                   :day (org-element-property :day-start elm)
+                   :hour (org-element-property :hour-start elm)
+                   :minute (org-element-property :minute-start elm)
+                   :second 0)))
+         (when (or (not last-ts)
+                   (ts> ts last-ts))
+           (setq last-ts ts))
+         (cl-incf ts-count)))
+     `((last-ts . ,last-ts)
+       (ts-count . ,ts-count)))))
+
 (provide 'octopus-org)
 ;;; octopus-org.el ends here

--- a/octopus-utils.el
+++ b/octopus-utils.el
@@ -135,5 +135,49 @@ which takes MAYBE-PROMPT as an argument, which see."
   (when-let (current (project-current maybe-prompt))
     (project-root current)))
 
+(defun octopus--frecency-timestamp-score (unix)
+  "Calculate the time score of the given UNIX time."
+  (let ((secs (- (float-time) unix)))
+    (cond
+     ((<= secs 14400)
+      100)
+     ((<= secs 86400)
+      80)
+     ((<= secs 259200)
+      60)
+     ((<= secs 604800)
+      40)
+     ((<= secs 2419200)
+      20)
+     ((<= secs 7776000)
+      10)
+     (t
+      0))))
+
+(defun octopus--format-time (time)
+  "Format TIME for human."
+  (let ((diff (- (float-time) time)))
+    (if (< diff (* 3600 48))
+        (octopus--format-duration diff)
+      (format-time-string "%F (%a)" time))))
+
+(defun octopus--format-duration (seconds)
+  "Format a time duration in SECONDS."
+  (cond
+   ((< seconds 120)
+    "just now")
+   ((< seconds 3600)
+    (format "%.f minutes ago" (/ seconds 60)))
+   ((< seconds (* 3600 24))
+    (format "%.f hours ago" (/ seconds 3600)))
+   ((< seconds (* 3600 24))
+    (format "%.f hours ago" (/ seconds 3600)))
+   ((< seconds (* 3600 24 60))
+    (format "%.f days ago" (/ seconds (* 3600 24))))
+   ((< seconds (* 3600 24 365))
+    (format "%.f months ago" (/ seconds (* 3600 24 30))))
+   (t
+    (format "%.f years ago" (/ seconds (* 3600 24 365))))))
+
 (provide 'octopus-utils)
 ;;; octopus-utils.el ends here


### PR DESCRIPTION
This is an alternative to `projectile-switch-project` or `project-switch-project`. It displays a list of projects sorted by frecency based on the timestamps of project entries.